### PR TITLE
Add support for writing core files of IOCs

### DIFF
--- a/config.example
+++ b/config.example
@@ -41,3 +41,11 @@ PORT=4050
 #   (the directory containing this file)
 #
 #CHDIR="$CHDIR"
+
+# Write a core file if process crashes and the size
+# of the corefile is not more than the value given
+# in bytes.
+#
+# By default no core files are generated.
+#
+#CORESIZE=10000000

--- a/softioc
+++ b/softioc
@@ -153,6 +153,10 @@ if [ -n "$LOG" -a "$LOG" != 0 ]; then
 	PROCARGS="$PROCARGS --logfile=$LOGDIR/$IOC.log"
 fi
 
+if [ -n $CORESIZE ]; then
+	PROCARGS="$PROCARGS --coresize=$CORESIZE"
+fi
+
 case "$1" in
 
 start)


### PR DESCRIPTION
Add support for a new variable CORESIZE that can be set in
/etc/default/epics-softioc or /etc/iocs/foo. Set it to the
maximum allowed size of a core file in bytes.
